### PR TITLE
kernel/userspace: migrate from miscdevice/ioctl to Generic Netlink API

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -1471,42 +1471,49 @@ static const struct genl_ops nomount_genl_ops[] = {
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_add_rule,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_DEL_RULE,
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_del_rule,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_CLEAR_ALL,
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_clear_rules,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_ADD_UID,
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_add_uid,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_DEL_UID,
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_del_uid,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_GET_LIST,
         .flags = GENL_ADMIN_PERM,
         .doit = NULL,
         .dumpit = nomount_genl_dump_rules,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
     {
         .cmd = NOMOUNT_CMD_GET_VERSION,
         .flags = GENL_ADMIN_PERM,
         .doit = nomount_genl_get_version,
         .dumpit = NULL,
+        NM_OPS_POLICY(nomount_genl_policy)
     },
 };
 
@@ -1514,7 +1521,7 @@ static struct genl_family nomount_genl_family = {
     .name = NOMOUNT_GENL_NAME,
     .version = NOMOUNT_GENL_VERSION,
     .maxattr = NOMOUNT_ATTR_MAX,
-    .policy = nomount_genl_policy,
+    NM_FAMILY_POLICY(nomount_genl_policy)
     .netnsok = true,
     .module = THIS_MODULE,
     .ops = nomount_genl_ops,

--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -4,7 +4,6 @@
 #include <linux/namei.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>
-#include <linux/miscdevice.h>
 #include <linux/cred.h>
 #include <linux/statfs.h>
 #include <linux/fs_struct.h>
@@ -1027,45 +1026,34 @@ int nomount_handle_getattr(int ret, const struct path *path, struct kstat *stat)
     return ret;
 }
 
-/*** IOCTL API & Module Management ***/
+/*** Generic Netlink API & Module Management ***/
 
-static int nomount_ioctl_add_rule(unsigned long arg)
+static struct genl_family nomount_genl_family;
+
+static int nomount_genl_add_rule(struct sk_buff *skb, struct genl_info *info)
 {
-    struct nomount_ioctl_data data;
     struct nomount_rule *rule, *existing, *victim = NULL;
     struct path path_main, r_path_struct_main;
     char *v_path, *r_path, *slash;
     const char *b_name;
     size_t v_len;
-    u32 hash, b_hash;
+    u32 hash, b_hash, flags;
     int err = 0;
     bool v_path_exists = false;
 
-    if (copy_from_user(&data, (void __user *)arg, sizeof(data))) {
-        nm_warn("Failed to copy rule data from userspace\n");
-        return -EFAULT;
-    }
+    if (!info->attrs[NOMOUNT_ATTR_VIRTUAL_PATH] || !info->attrs[NOMOUNT_ATTR_REAL_PATH])
+        return -EINVAL;
 
-    if (!capable(CAP_SYS_ADMIN)) {
-        nm_warn("Permission denied: CAP_SYS_ADMIN required\n");
-        return -EPERM;
-    }
-
-    /* Fetch virtual_path from userspace */
-    v_path = strndup_user((const char __user *)(unsigned long)data.virtual_path, PATH_MAX);
-    if (IS_ERR(v_path)) {
-        nm_err("Failed to allocate or copy virtual path\n");
-        return PTR_ERR(v_path);
-    }
-
-    /* Fetch real_path from userspace */
-    r_path = strndup_user((const char __user *)(unsigned long)data.real_path, PATH_MAX);
-    if (IS_ERR(r_path)) {
-        nm_err("Failed to allocate or copy real path\n");
-        kfree(v_path); /* Safe to free since v_path succeeded above */
-        return PTR_ERR(r_path);
-    }
+    v_path = kstrdup(nla_data(info->attrs[NOMOUNT_ATTR_VIRTUAL_PATH]), GFP_KERNEL);
+    r_path = kstrdup(nla_data(info->attrs[NOMOUNT_ATTR_REAL_PATH]), GFP_KERNEL);
+    flags = info->attrs[NOMOUNT_ATTR_FLAGS] ? nla_get_u32(info->attrs[NOMOUNT_ATTR_FLAGS]) : 0;
     
+    if (!v_path || !r_path) {
+        kfree(v_path); 
+        kfree(r_path);
+        return -ENOMEM;
+    }
+
     v_len = strlen(v_path);
     hash = full_name_hash(NULL, v_path, v_len);
 
@@ -1093,7 +1081,7 @@ static int nomount_ioctl_add_rule(unsigned long arg)
     rule->b_len = strlen(b_name);
 
     rule->v_hash = hash;
-    rule->flags = data.flags;
+    rule->flags = flags;
 
     rule->real_ino = 0;
     rule->real_dev = 0;
@@ -1150,7 +1138,7 @@ static int nomount_ioctl_add_rule(unsigned long arg)
     }
 
     if (!v_path_exists) {
-        err = nomount_generate_virtual_topology(rule, v_path, r_path, v_len, data.flags);
+        err = nomount_generate_virtual_topology(rule, v_path, r_path, v_len, flags);
         if (err != 0) {
             up_write(&nomount_dirs_rwsem);
             mutex_unlock(&nomount_write_mutex);
@@ -1191,9 +1179,8 @@ static int nomount_ioctl_add_rule(unsigned long arg)
     return 0;
 }
 
-static int nomount_ioctl_del_rule(unsigned long arg)
+static int nomount_genl_del_rule(struct sk_buff *skb, struct genl_info *info)
 {
-    struct nomount_ioctl_data data;
     struct nomount_rule *rule, *victim = NULL;
     struct nomount_dir_node *dir, *victim_dir = NULL;
     struct nomount_child_name *child, *victim_child = NULL;
@@ -1202,17 +1189,15 @@ static int nomount_ioctl_del_rule(unsigned long arg)
     u32 hash;
     int bkt;
 
-    if (copy_from_user(&data, (void __user *)arg, sizeof(data)))
-        return -EFAULT;
-
-    if (!capable(CAP_SYS_ADMIN))
-        return -EPERM;
-
     if (unlikely(nomount_num_rules() == 0))
         return -ENOENT;
 
-    v_path = strndup_user((const char __user *)(unsigned long)data.virtual_path, PATH_MAX);
-    if (IS_ERR(v_path)) return PTR_ERR(v_path);
+    if (!info->attrs[NOMOUNT_ATTR_VIRTUAL_PATH])
+        return -EINVAL;
+
+    v_path = kstrdup(nla_data(info->attrs[NOMOUNT_ATTR_VIRTUAL_PATH]), GFP_KERNEL);
+    if (!v_path)
+        return -ENOMEM;
     
     v_len = strlen(v_path);
     hash = full_name_hash(NULL, v_path, v_len);
@@ -1278,7 +1263,7 @@ ghost_found:
     return -ENOENT;
 }
 
-static int nomount_ioctl_clear_rules(void)
+static int nomount_genl_clear_rules(struct sk_buff *skb, struct genl_info *info)
 {
     struct nomount_rule *rule, *tmp_rule;
     struct nomount_uid_node *uid_node;
@@ -1290,9 +1275,6 @@ static int nomount_ioctl_clear_rules(void)
     HLIST_HEAD(uid_victims);
     HLIST_HEAD(dir_victims);
     int bkt;
-    
-    if (!capable(CAP_SYS_ADMIN))
-        return -EPERM;
 
     mutex_lock(&nomount_write_mutex);
     down_write(&nomount_dirs_rwsem);
@@ -1353,76 +1335,60 @@ static int nomount_ioctl_clear_rules(void)
     return 0;
 }
 
-static int nomount_ioctl_list_rules(unsigned long arg)
+static int nomount_genl_dump_rules(struct sk_buff *skb, struct netlink_callback *cb)
 {
     struct nomount_rule *rule;
-    char *kbuf;
-    size_t total_required = 0;
-    size_t pos = 0;
-    int ret = 0;
+    int idx = 0;
+    int start_idx = cb->args[0];
 
     mutex_lock(&nomount_write_mutex);
-    list_for_each_entry(rule, &nomount_rules_list, list) {
-        total_required += sizeof(u16) * 2 + (rule->vp_len + 1) + (rule->rp_len + 1);
-    }
-
-    if (total_required == 0) {
-        mutex_unlock(&nomount_write_mutex);
-        return 0;
-    }
-
-    kbuf = kvmalloc(total_required, GFP_KERNEL);
-    if (!kbuf) {
-        mutex_unlock(&nomount_write_mutex);
-        nm_err("Failed to allocate %zu bytes for listing rules\n", total_required);
-        return -ENOMEM;
-    }
 
     list_for_each_entry(rule, &nomount_rules_list, list) {
-        u16 v_len = rule->vp_len + 1; 
-        u16 r_len = rule->rp_len + 1;
-        u16 step_len = sizeof(u16) * 2 + v_len + r_len;
+        if (idx < start_idx) {
+            idx++;
+            continue;
+        }
 
-        if (pos + step_len > total_required) break;
+        void *hdr = genlmsg_put(skb, NETLINK_CB(cb->skb).portid, cb->nlh->nlmsg_seq,
+                                &nomount_genl_family, NLM_F_MULTI, NOMOUNT_CMD_GET_LIST);
+        if (!hdr)
+            break;
 
-        put_unaligned(step_len, (u16 *)(kbuf + pos));
-        pos += sizeof(u16);
+        if (nla_put_string(skb, NOMOUNT_ATTR_VIRTUAL_PATH, rule->virtual_path) ||
+            nla_put_string(skb, NOMOUNT_ATTR_REAL_PATH, rule->real_path) ||
+            nla_put_u32(skb, NOMOUNT_ATTR_FLAGS, rule->flags)) {
 
-        put_unaligned(v_len, (u16 *)(kbuf + pos));
-        pos += sizeof(u16);
+            genlmsg_cancel(skb, hdr);
+            break;
+        }
 
-        memcpy(kbuf + pos, rule->virtual_path, v_len);
-        pos += v_len;
-
-        memcpy(kbuf + pos, rule->real_path, r_len);
-        pos += r_len;
+        genlmsg_end(skb, hdr);
+        idx++;
     }
 
     mutex_unlock(&nomount_write_mutex);
 
-    if (copy_to_user((void __user *)arg, kbuf, pos)) {
-        nm_warn("-EFAULT while copying rule list to userspace\n");
-        ret = -EFAULT;
-    } else {
-        ret = (int)pos; 
-    }
-
-    kvfree(kbuf);
-    return ret;
+    cb->args[0] = idx; 
+    
+    return skb->len;
 }
 
-static int nomount_ioctl_add_uid(unsigned long arg)
+static int nomount_genl_add_uid(struct sk_buff *skb, struct genl_info *info)
 {
     unsigned int uid;
     struct nomount_uid_node *entry;
 
-    if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
-        return -EFAULT;
-    
-    if (nomount_is_uid_blocked(uid)) return -EEXIST;
+    if (!info->attrs[NOMOUNT_ATTR_UID])
+        return -EINVAL;
+
+    uid = nla_get_u32(info->attrs[NOMOUNT_ATTR_UID]);
+
+    if (nomount_is_uid_blocked(uid)) 
+        return -EEXIST;
 
     entry = kmem_cache_alloc(nm_uid_cachep, GFP_KERNEL);
-    if (!entry) return -ENOMEM;
+    if (!entry) 
+        return -ENOMEM;
 
     entry->uid = uid;
     
@@ -1430,10 +1396,11 @@ static int nomount_ioctl_add_uid(unsigned long arg)
     hash_add_rcu(nomount_uid_ht, &entry->node, uid);
     mutex_unlock(&nomount_write_mutex);
     
+    nm_info("Successfully added blocked UID: %u via Netlink\n", uid);
     return 0;
 }
 
-static int nomount_ioctl_del_uid(unsigned long arg)
+static int nomount_genl_del_uid(struct sk_buff *skb, struct genl_info *info)
 {
     unsigned int uid;
     struct nomount_uid_node *entry;
@@ -1441,8 +1408,10 @@ static int nomount_ioctl_del_uid(unsigned long arg)
     int bkt;
     bool found = false;
 
-    if (copy_from_user(&uid, (void __user *)arg, sizeof(uid)))
-        return -EFAULT;
+    if (!info->attrs[NOMOUNT_ATTR_UID])
+        return -EINVAL;
+
+    uid = nla_get_u32(info->attrs[NOMOUNT_ATTR_UID]);
 
     mutex_lock(&nomount_write_mutex);
     hash_for_each_safe(nomount_uid_ht, bkt, tmp, entry, node) {
@@ -1462,36 +1431,94 @@ static int nomount_ioctl_del_uid(unsigned long arg)
     return found ? 0 : -ENOENT;
 }
 
-static long nomount_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static int nomount_genl_get_version(struct sk_buff *skb, struct genl_info *info)
 {
-    if (_IOC_TYPE(cmd) != NOMOUNT_MAGIC_CODE)
-        return -ENOTTY;
+    struct sk_buff *msg;
+    void *hdr;
+    int ret;
 
-    switch (cmd) {
-    case NOMOUNT_IOC_GET_VERSION: return NOMOUNT_VERSION;
-    case NOMOUNT_IOC_ADD_RULE:    return nomount_ioctl_add_rule(arg);
-    case NOMOUNT_IOC_DEL_RULE:    return nomount_ioctl_del_rule(arg);
-    case NOMOUNT_IOC_CLEAR_ALL:   return nomount_ioctl_clear_rules();
-    case NOMOUNT_IOC_ADD_UID:     return nomount_ioctl_add_uid(arg);
-    case NOMOUNT_IOC_DEL_UID:     return nomount_ioctl_del_uid(arg);
-    case NOMOUNT_IOC_GET_LIST:    return nomount_ioctl_list_rules(arg);
-    default: return -ENOTTY;
+    msg = genlmsg_new(NLMSG_DEFAULT_SIZE, GFP_KERNEL);
+    if (!msg) return -ENOMEM;
+
+    hdr = genlmsg_put_reply(msg, info, &nomount_genl_family, 0, info->genlhdr->cmd);
+    if (!hdr) {
+        nlmsg_free(msg);
+        return -EMSGSIZE;
     }
+
+    ret = nla_put_u32(msg, NOMOUNT_ATTR_VERSION, NOMOUNT_VERSION);
+    if (ret) {
+        genlmsg_cancel(msg, hdr);
+        nlmsg_free(msg);
+        return ret;
+    }
+
+    genlmsg_end(msg, hdr);
+    return genlmsg_reply(msg, info);
 }
 
-static const struct file_operations nomount_fops = {
-    .owner = THIS_MODULE,
-    .unlocked_ioctl = nomount_ioctl,
-#ifdef CONFIG_COMPAT
-    .compat_ioctl = nomount_ioctl,
-#endif
+static const struct nla_policy nomount_genl_policy[NOMOUNT_ATTR_MAX + 1] = {
+    [NOMOUNT_ATTR_VIRTUAL_PATH] = { .type = NLA_NUL_STRING, .len = PATH_MAX },
+    [NOMOUNT_ATTR_REAL_PATH]    = { .type = NLA_NUL_STRING, .len = PATH_MAX },
+    [NOMOUNT_ATTR_FLAGS]        = { .type = NLA_U32 },
+    [NOMOUNT_ATTR_UID]          = { .type = NLA_U32 },
+    [NOMOUNT_ATTR_VERSION]      = { .type = NLA_U32 },
 };
 
-static struct miscdevice nomount_device = {
-    .minor = MISC_DYNAMIC_MINOR, 
-    .name = "nomount", 
-    .fops = &nomount_fops, 
-    .mode = 0600,
+static const struct genl_ops nomount_genl_ops[] = {
+    {
+        .cmd = NOMOUNT_CMD_ADD_RULE,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_add_rule,
+        .dumpit = NULL,
+    },
+    {
+        .cmd = NOMOUNT_CMD_DEL_RULE,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_del_rule,
+        .dumpit = NULL,
+    },
+    {
+        .cmd = NOMOUNT_CMD_CLEAR_ALL,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_clear_rules,
+        .dumpit = NULL,
+    },
+    {
+        .cmd = NOMOUNT_CMD_ADD_UID,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_add_uid,
+        .dumpit = NULL,
+    },
+    {
+        .cmd = NOMOUNT_CMD_DEL_UID,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_del_uid,
+        .dumpit = NULL,
+    },
+    {
+        .cmd = NOMOUNT_CMD_GET_LIST,
+        .flags = GENL_ADMIN_PERM,
+        .doit = NULL,
+        .dumpit = nomount_genl_dump_rules,
+    },
+    {
+        .cmd = NOMOUNT_CMD_GET_VERSION,
+        .flags = GENL_ADMIN_PERM,
+        .doit = nomount_genl_get_version,
+        .dumpit = NULL,
+    },
+};
+
+static struct genl_family nomount_genl_family = {
+    .name = NOMOUNT_GENL_NAME,
+    .version = NOMOUNT_GENL_VERSION,
+    .maxattr = NOMOUNT_ATTR_MAX,
+    .policy = nomount_genl_policy,
+    .netnsok = true,
+    .module = THIS_MODULE,
+    .ops = nomount_genl_ops,
+    .n_ops = ARRAY_SIZE(nomount_genl_ops),
 };
 
 static int __init nomount_init(void) {
@@ -1523,9 +1550,9 @@ static int __init nomount_init(void) {
         return -ENOMEM;
     }
 
-    ret = misc_register(&nomount_device);
+    ret = genl_register_family(&nomount_genl_family);
     if (ret) {
-        nm_err("Failed to register misc device '/dev/nomount' (err: %d)\n", ret);
+        nm_err("Failed to register Generic Netlink family (err: %d)\n", ret);
         kmem_cache_destroy(nm_rule_cachep);
         kmem_cache_destroy(nm_dir_cachep);
         kmem_cache_destroy(nm_uid_cachep);

--- a/kernel/src/nomount.h
+++ b/kernel/src/nomount.h
@@ -5,21 +5,14 @@
 #include <linux/list.h>
 #include <linux/hashtable.h>
 #include <linux/atomic.h>
-#include <linux/ioctl.h>
 #include <linux/rwsem.h>
+#include <net/sock.h>
+#include <net/genetlink.h>
 
-#define NOMOUNT_MAGIC_CODE 0x4E /* 'N' */
 #define NOMOUNT_VERSION    2
 #define NOMOUNT_HASH_BITS  12
 #define NOMOUNT_UID_HASH_BITS 4
 #define NM_FLAG_IS_DIR        (1 << 7)
-#define NOMOUNT_IOC_ADD_RULE    _IOW(NOMOUNT_MAGIC_CODE, 1, struct nomount_ioctl_data)
-#define NOMOUNT_IOC_DEL_RULE    _IOW(NOMOUNT_MAGIC_CODE, 2, struct nomount_ioctl_data)
-#define NOMOUNT_IOC_CLEAR_ALL   _IO(NOMOUNT_MAGIC_CODE,  3)
-#define NOMOUNT_IOC_GET_VERSION _IOR(NOMOUNT_MAGIC_CODE, 4, int)
-#define NOMOUNT_IOC_ADD_UID     _IOW(NOMOUNT_MAGIC_CODE, 5, unsigned int)
-#define NOMOUNT_IOC_DEL_UID     _IOW(NOMOUNT_MAGIC_CODE, 6, unsigned int)
-#define NOMOUNT_IOC_GET_LIST    _IOR(NOMOUNT_MAGIC_CODE, 7, int)
 
 static DEFINE_HASHTABLE(nomount_dirs_ht,           NOMOUNT_HASH_BITS);
 static DEFINE_HASHTABLE(nomount_rules_by_vpath,    NOMOUNT_HASH_BITS);
@@ -32,11 +25,6 @@ static LIST_HEAD(nomount_private_dirs_list);
 static DEFINE_MUTEX(nomount_write_mutex);
 static DECLARE_RWSEM(nomount_dirs_rwsem);
 
-struct nomount_ioctl_data {
-    u64 virtual_path;
-    u64 real_path;
-    u32 flags;
-};
 
 struct nomount_rule {
     struct hlist_node v_ino_node;
@@ -83,6 +71,41 @@ struct nomount_uid_node {
     struct hlist_node node;
     uid_t uid;
 };
+
+/* ========================================================================= */
+/* NETLINK GENERIC PROTOCOL DEFINITIONS */
+/* ========================================================================= */
+
+#define NOMOUNT_GENL_NAME "nomount"
+#define NOMOUNT_GENL_VERSION 1
+
+/* Commands */
+enum {
+    NOMOUNT_CMD_UNSPEC = 0,
+    NOMOUNT_CMD_GET_VERSION,
+    NOMOUNT_CMD_ADD_RULE,
+    NOMOUNT_CMD_DEL_RULE,
+    NOMOUNT_CMD_CLEAR_ALL,
+    NOMOUNT_CMD_ADD_UID,
+    NOMOUNT_CMD_DEL_UID,
+    NOMOUNT_CMD_GET_LIST,
+    __NOMOUNT_CMD_MAX,
+};
+#define NOMOUNT_CMD_MAX (__NOMOUNT_CMD_MAX - 1)
+
+/* Attributes */
+enum {
+    NOMOUNT_ATTR_UNSPEC = 0,
+    NOMOUNT_ATTR_VIRTUAL_PATH,  /* String (NLA_NUL_STRING) */
+    NOMOUNT_ATTR_REAL_PATH,     /* String (NLA_NUL_STRING) */
+    NOMOUNT_ATTR_FLAGS,         /* u32 (NLA_U32) */
+    NOMOUNT_ATTR_UID,           /* u32 (NLA_U32) */
+    NOMOUNT_ATTR_VERSION,       /* u32 (NLA_U32) */
+    NOMOUNT_ATTR_PAYLOAD,       /* Binary payload for GET_LIST (NLA_BINARY) */
+    __NOMOUNT_ATTR_MAX,
+};
+
+#define NOMOUNT_ATTR_MAX (__NOMOUNT_ATTR_MAX - 1)
 
 /*
  * Recursion tracking for nomount operations. 

--- a/kernel/src/nomount.h
+++ b/kernel/src/nomount.h
@@ -8,6 +8,7 @@
 #include <linux/rwsem.h>
 #include <net/sock.h>
 #include <net/genetlink.h>
+#include <linux/version.h>
 
 #define NOMOUNT_VERSION    2
 #define NOMOUNT_HASH_BITS  12
@@ -106,6 +107,17 @@ enum {
 };
 
 #define NOMOUNT_ATTR_MAX (__NOMOUNT_ATTR_MAX - 1)
+
+/* * Compat macros for Generic Netlink Policy API changes.
+ * Linux 4.20 moved the policy pointer from genl_ops to genl_family.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+#define NM_OPS_POLICY(p)    .policy = (p),
+#define NM_FAMILY_POLICY(p)
+#else
+#define NM_OPS_POLICY(p)
+#define NM_FAMILY_POLICY(p) .policy = (p),
+#endif
 
 /*
  * Recursion tracking for nomount operations. 

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -1,6 +1,6 @@
 ui_print " "
 ui_print "======================================="
-ui_print "               NoMount                 "
+ui_print "                NoMount                "
 ui_print "  Native Kernel Injection Metamodule   "
 ui_print "======================================="
 ui_print " "
@@ -14,16 +14,17 @@ mv "$MODPATH/bin/nm-$ARCH" "$MODPATH/bin/nm"
 set_perm "$MODPATH/bin/nm" 0 0 0755
 rm -rf $MODPATH/bin/nm-*
 
-ui_print "- Checking Kernel support..."
-if [ -e "/dev/nomount" ]; then
-  ui_print "  [OK] Driver /dev/nomount detected."
+ui_print "- Checking Kernel support via Netlink..."
+
+if "$MODPATH/bin/nm" v > /dev/null 2>&1; then
+  ui_print "  [OK] NoMount Netlink interface detected."
   ui_print "  [OK] System is ready for injection."
 else
   ui_print " "
   ui_print "***************************************************"
   ui_print "* [!] WARNING: KERNEL DRIVER NOT DETECTED         *"
   ui_print "***************************************************"
-  ui_print "* The device node /dev/nomount is missing.        *"
+  ui_print "* The NoMount Netlink interface is unresponsive.  *"
   ui_print "* *"
   ui_print "* This module will NOT FUNCTION until you flash   *"
   ui_print "* a Kernel compiled with CONFIG_NOMOUNT=y         *"
@@ -33,9 +34,8 @@ else
   touch "$MODPATH/disable"
 fi
 
-if [ -f "/data/adb/nomount" ]; then
+if [ -d "/data/adb/nomount" ]; then
     rm -rf "/data/adb/nomount"
 fi
 
 ui_print "- Installation complete."
-

--- a/module/metamount.sh
+++ b/module/metamount.sh
@@ -24,11 +24,12 @@ else
     echo "[CONFIG] Verbose Mode: OFF (Summary only)" >> "$LOG_FILE"
 fi
 
-if [ ! -e "/dev/nomount" ]; then
-    echo "[FATAL] /dev/nomount missing. Is the kernel patched?" >> "$LOG_FILE"
+if ! "$LOADER" v > /dev/null 2>&1; then
+    echo "[FATAL] NoMount Netlink interface missing/unresponsive. Is the kernel patched?" >> "$LOG_FILE"
     touch "$MODDIR/disable"
     exit 1
 fi
+echo "[OK] Netlink socket responding properly." >> "$LOG_FILE"
 
 for mod_path in "$MODULES_DIR"/*; do
     [ -d "$mod_path" ] || continue

--- a/userspace/src/nm.c
+++ b/userspace/src/nm.c
@@ -1,77 +1,268 @@
 /*
- * nm.c - NoMount CLI Userspace Tool 
+ * nm.c - NoMount CLI Userspace Tool
+ *
  */
 
 /* --- ARCH --- */
 #if defined(__aarch64__)
     #define SYS_GETCWD     17
-    #define SYS_IOCTL      29
-    #define SYS_OPENAT     56
     #define SYS_CLOSE      57
     #define SYS_WRITE      64
     #define SYS_EXIT       93
+    #define SYS_SOCKET     198
+    #define SYS_BIND       200
+    #define SYS_SENDTO     206
+    #define SYS_RECVFROM   207
 
     __attribute__((always_inline))
-    static inline long sys4(long n, long a, long b, long c, long d) {
+    static inline long sys6(long n, long a, long b, long c, long d, long e, long f) {
         register long x8 asm("x8") = n;
         register long x0 asm("x0") = a;
         register long x1 asm("x1") = b;
         register long x2 asm("x2") = c;
         register long x3 asm("x3") = d;
-        __asm__ __volatile__("svc 0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2), "r"(x3) : "memory", "cc");
+        register long x4 asm("x4") = e;
+        register long x5 asm("x5") = f;
+        __asm__ __volatile__("svc 0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x5) : "memory", "cc");
         return x0;
     }
-    #define sys1(n,a) sys4(n,a,0,0,0)
-    #define sys2(n,a,b) sys4(n,a,b,0,0)
-    #define sys3(n,a,b,c) sys4(n,a,b,c,0)
+    #define sys1(n,a) sys6(n,a,0,0,0,0,0)
+    #define sys2(n,a,b) sys6(n,a,b,0,0,0,0)
+    #define sys3(n,a,b,c) sys6(n,a,b,c,0,0,0)
+    #define sys4(n,a,b,c,d) sys6(n,a,b,c,d,0,0)
     __attribute__((naked)) void _start(void) { __asm__ volatile("mov x0, sp\n bl c_main\n"); }
 
 #elif defined(__arm__)
     #define SYS_EXIT       1
     #define SYS_WRITE      4
     #define SYS_CLOSE      6
-    #define SYS_IOCTL      54
     #define SYS_GETCWD     183
-    #define SYS_OPENAT     322
+    #define SYS_SOCKET     281
+    #define SYS_BIND       282
+    #define SYS_SENDTO     290
+    #define SYS_RECVFROM   292
 
     __attribute__((always_inline))
-    static inline long sys4(long n, long a, long b, long c, long d) {
+    static inline long sys6(long n, long a, long b, long c, long d, long e, long f) {
         register long r7 asm("r7") = n;
         register long r0 asm("r0") = a;
         register long r1 asm("r1") = b;
         register long r2 asm("r2") = c;
         register long r3 asm("r3") = d;
-        __asm__ __volatile__("svc 0" : "+r"(r0) : "r"(r7), "r"(r1), "r"(r2), "r"(r3) : "memory", "cc");
+        register long r4 asm("r4") = e;
+        register long r5 asm("r5") = f;
+        __asm__ __volatile__("svc 0" : "+r"(r0) : "r"(r7), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5) : "memory", "cc");
         return r0;
     }
-    #define sys1(n,a) sys4(n,a,0,0,0)
-    #define sys2(n,a,b) sys4(n,a,b,0,0)
-    #define sys3(n,a,b,c) sys4(n,a,b,c,0)
+    #define sys1(n,a) sys6(n,a,0,0,0,0,0)
+    #define sys2(n,a,b) sys6(n,a,b,0,0,0,0)
+    #define sys3(n,a,b,c) sys6(n,a,b,c,0,0,0)
+    #define sys4(n,a,b,c,d) sys6(n,a,b,c,d,0,0)
     __attribute__((naked)) void _start(void) { __asm__ volatile("mov r0, sp\n bl c_main\n"); }
 #else
     #error "Arch not supported"
 #endif
 
-/* --- DEFS --- */
+/* --- UTILS --- */
 typedef unsigned long size_t;
-#define AT_FDCWD -100
-#define O_RDWR 2
+#define PATH_MAX  4096
+#define NULL ((void *)0)
 
-struct ioctl_data {
-    unsigned long long vp;
-    unsigned long long rp;
-    unsigned int flags;
+void *memset(void *dst, int c, size_t n) {
+    char *d = (char *)dst;
+    while (n--) *d++ = (char)c;
+    return dst;
+}
+
+void *memcpy(void *dst, const void *src, size_t n) {
+    char *d = (char *)dst;
+    const char *s = (const char *)src;
+    while (n--) *d++ = *s++;
+    return dst;
+}
+
+size_t strlen(const char *s) {
+    size_t len = 0;
+    while (s[len]) len++;
+    return len;
+}
+
+#define printc(str) sys3(SYS_WRITE, 1, (long)str, sizeof(str) - 1)
+
+/* --- NETLINK DEFS --- */
+#define AF_NETLINK 16
+#define SOCK_RAW 3
+#define NETLINK_GENERIC 16
+
+/* Netlink Message Flags */
+#define NLM_F_REQUEST 1
+#define NLM_F_ACK 4
+#define NLM_F_ROOT 0x100
+#define NLM_F_MATCH 0x200
+#define NLM_F_DUMP (NLM_F_ROOT | NLM_F_MATCH)
+
+#define NLMSG_ERROR 2
+#define NLMSG_DONE 3
+
+/* Alignment Macros (Crucial for Netlink) */
+#define NLMSG_ALIGNTO 4U
+#define NLMSG_ALIGN(len) (((len) + NLMSG_ALIGNTO - 1) & ~(NLMSG_ALIGNTO - 1))
+#define NLMSG_HDRLEN NLMSG_ALIGN(sizeof(struct nlmsghdr))
+
+#define NLMSG_OK(nlh, len) \
+    ((len) >= (int)sizeof(struct nlmsghdr) && \
+     (nlh)->nlmsg_len >= sizeof(struct nlmsghdr) && \
+     (nlh)->nlmsg_len <= (len))
+
+#define NLMSG_NEXT(nlh, len) \
+    ((len) -= NLMSG_ALIGN((nlh)->nlmsg_len), \
+     (struct nlmsghdr *)(((char *)(nlh)) + NLMSG_ALIGN((nlh)->nlmsg_len)))
+
+#define NLA_ALIGNTO 4U
+#define NLA_ALIGN(len) (((len) + NLA_ALIGNTO - 1) & ~(NLA_ALIGNTO - 1))
+#define NLA_HDRLEN NLA_ALIGN(sizeof(struct nlattr))
+
+struct sockaddr_nl {
+    unsigned short nl_family;
+    unsigned short nl_pad;
+    unsigned int   nl_pid;
+    unsigned int   nl_groups;
 };
 
-#define IOCTL_ADD     0x40184E01
-#define IOCTL_DEL     0x40184E02
-#define IOCTL_CLEAR   0x00004E03
-#define IOCTL_VER     0x80044E04
-#define IOCTL_ADD_UID 0x40044E05
-#define IOCTL_DEL_UID 0x40044E06
-#define IOCTL_LIST    0x80044E07
+struct nlmsghdr {
+    unsigned int   nlmsg_len;
+    unsigned short nlmsg_type;
+    unsigned short nlmsg_flags;
+    unsigned int   nlmsg_seq;
+    unsigned int   nlmsg_pid;
+};
 
-#define PATH_MAX  4096
+struct nlmsgerr {
+    int error;
+    struct nlmsghdr msg;
+};
+
+struct genlmsghdr {
+    unsigned char cmd;
+    unsigned char version;
+    unsigned short reserved;
+};
+
+struct nlattr {
+    unsigned short nla_len;
+    unsigned short nla_type;
+};
+
+/* --- NOMOUNT GENL DEFS --- */
+#define GENL_ID_CTRL 16
+#define CTRL_CMD_GETFAMILY 3
+#define CTRL_ATTR_FAMILY_ID 1
+#define CTRL_ATTR_FAMILY_NAME 2
+
+#define NOMOUNT_CMD_GET_VERSION 1
+#define NOMOUNT_CMD_ADD_RULE 2
+#define NOMOUNT_CMD_DEL_RULE 3
+#define NOMOUNT_CMD_CLEAR_ALL 4
+#define NOMOUNT_CMD_ADD_UID 5
+#define NOMOUNT_CMD_DEL_UID 6
+#define NOMOUNT_CMD_GET_LIST 7
+
+#define NOMOUNT_ATTR_VIRTUAL_PATH 1
+#define NOMOUNT_ATTR_REAL_PATH 2
+#define NOMOUNT_ATTR_FLAGS 3
+#define NOMOUNT_ATTR_UID 4
+#define NOMOUNT_ATTR_VERSION 5
+#define NOMOUNT_ATTR_PAYLOAD 6
+
+/* --- NETLINK ENGINE --- */
+static int nl_seq = 0;
+static char tx_buf[16384];
+static char rx_buf[16384];
+
+/* Initialize a new Netlink message */
+static struct nlmsghdr *init_msg(int type, int cmd, int flags) {
+    memset(tx_buf, 0, sizeof(tx_buf));
+    struct nlmsghdr *nlh = (struct nlmsghdr *)tx_buf;
+    nlh->nlmsg_type = type;
+    nlh->nlmsg_flags = flags;
+    nlh->nlmsg_seq = ++nl_seq;
+    nlh->nlmsg_pid = 0; /* Auto-assign */
+
+    struct genlmsghdr *gnlh = (struct genlmsghdr *)(tx_buf + NLMSG_HDRLEN);
+    gnlh->cmd = cmd;
+    gnlh->version = 1;
+
+    nlh->nlmsg_len = NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct genlmsghdr));
+    return nlh;
+}
+
+/* Append an attribute to the message */
+static void add_attr(struct nlmsghdr *nlh, int type, const void *data, int len) {
+    int attr_len = NLA_HDRLEN + len;
+    struct nlattr *nla = (struct nlattr *)((char *)nlh + NLMSG_ALIGN(nlh->nlmsg_len));
+    nla->nla_type = type;
+    nla->nla_len = attr_len;
+    memcpy((char *)nla + NLA_HDRLEN, data, len);
+    nlh->nlmsg_len = NLMSG_ALIGN(nlh->nlmsg_len) + NLA_ALIGN(attr_len);
+}
+
+/* Helper to parse attributes from a packet */
+static void parse_attrs(struct nlattr **tb, int max, struct nlattr *attr, int len) {
+    memset(tb, 0, sizeof(struct nlattr *) * (max + 1));
+    while (len >= NLA_HDRLEN) {
+        if (attr->nla_len >= NLA_HDRLEN && attr->nla_type <= max) {
+            tb[attr->nla_type] = attr;
+        }
+        int aligned_len = NLA_ALIGN(attr->nla_len);
+        if (aligned_len == 0 || aligned_len > len) break;
+        attr = (struct nlattr *)((char *)attr + aligned_len);
+        len -= aligned_len;
+    }
+}
+
+/* Send packet and wait for ACK or Data */
+static int send_and_recv(int fd, struct nlmsghdr *nlh) {
+    struct sockaddr_nl dest = { .nl_family = AF_NETLINK };
+    long res = sys6(SYS_SENDTO, fd, (long)nlh, nlh->nlmsg_len, 0, (long)&dest, sizeof(dest));
+    if (res < 0) return res;
+
+    res = sys6(SYS_RECVFROM, fd, (long)rx_buf, sizeof(rx_buf), 0, 0, 0);
+    if (res < 0) return res;
+
+    struct nlmsghdr *rep = (struct nlmsghdr *)rx_buf;
+    if (rep->nlmsg_type == NLMSG_ERROR) {
+        struct nlmsgerr *err = (struct nlmsgerr *)((char *)rep + NLMSG_HDRLEN);
+        return err->error; /* 0 means ACK success, <0 means error */
+    }
+    return res; /* Return bytes read */
+}
+
+/* Get the dynamic Family ID of NoMount */
+static int get_nomount_family_id(int fd) {
+    struct nlmsghdr *nlh = init_msg(GENL_ID_CTRL, CTRL_CMD_GETFAMILY, NLM_F_REQUEST);
+    const char *name = "nomount";
+    add_attr(nlh, CTRL_ATTR_FAMILY_NAME, name, strlen(name) + 1);
+
+    if (send_and_recv(fd, nlh) > 0) {
+        struct nlmsghdr *rep = (struct nlmsghdr *)rx_buf;
+        if (rep->nlmsg_type != NLMSG_ERROR) {
+            struct nlattr *tb[3]; // Max attr is CTRL_ATTR_FAMILY_NAME(2)
+            struct nlattr *attrs = (struct nlattr *)((char *)rep + NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct genlmsghdr)));
+            int attr_len = rep->nlmsg_len - NLMSG_HDRLEN - NLMSG_ALIGN(sizeof(struct genlmsghdr));
+            
+            parse_attrs(tb, 2, attrs, attr_len);
+            if (tb[CTRL_ATTR_FAMILY_ID]) {
+                return *(unsigned short *)((char *)tb[CTRL_ATTR_FAMILY_ID] + NLA_HDRLEN);
+            }
+        }
+    }
+    return -1;
+}
+
+/* --- MAIN --- */
+static char v_resolved[PATH_MAX];
+static char r_resolved[PATH_MAX];
+static char cwd_buf[PATH_MAX];
 
 /* complete path resolution */
 __attribute__((noinline))
@@ -102,14 +293,6 @@ static int resolve_path(char *result, const char *cwd, const char *rel_path, int
     return r_pos;
 }
 
-#define printc(str) sys3(SYS_WRITE, 1, (long)str, sizeof(str) - 1)
-
-static char v_resolved[PATH_MAX];
-static char r_resolved[PATH_MAX];
-static char cwd_buf[PATH_MAX];
-static char list_buf[33554432];
-
-/* --- MAIN --- */
 __attribute__((noreturn, used))
 void c_main(long *sp) {
     long argc = *sp;
@@ -121,163 +304,154 @@ void c_main(long *sp) {
         goto do_exit;
     }
 
-    int fd = sys4(SYS_OPENAT, AT_FDCWD, (long)"/dev/nomount", O_RDWR, 0);
-    if (fd < 0) {
-        exit_code = (long)(-fd);
+    /* 1. Setup Netlink Socket */
+    int fd = sys3(SYS_SOCKET, AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
+    if (fd < 0) { exit_code = 2; goto do_exit; }
+
+    struct sockaddr_nl local = { .nl_family = AF_NETLINK };
+    sys3(SYS_BIND, fd, (long)&local, sizeof(local));
+
+    /* 2. Resolve 'nomount' Family ID */
+    int nm_family = get_nomount_family_id(fd);
+    if (nm_family < 0) {
+        printc("Error: NoMount kernel module not loaded.\n");
+        exit_code = 3; 
         goto do_exit;
     }
 
     char cmd = argv[1][0];
-    struct ioctl_data data = {0};
-    void *ioctl_arg = 0;
-    unsigned int uid = 0;
-    long ioctl_code = 0;
+    struct nlmsghdr *nlh = NULL;
+    int req_flags = NLM_F_REQUEST | NLM_F_ACK;
 
     switch (cmd) {
         case 'a':
-        case 'd':
-        case 'r': {
+        case 'd': {
             int is_add = (cmd == 'a');
             int step = is_add ? 2 : 1;
             if (argc < 2 + step) goto do_exit;
 
             long cwd_len = sys2(SYS_GETCWD, (long)cwd_buf, PATH_MAX);
             const char *cwd = (cwd_len > 0) ? cwd_buf : "/";
-
-            exit_code = 0; 
+            exit_code = 0;
 
             for (int arg_idx = 2; arg_idx + step <= argc; arg_idx += step) {
                 int v_len = resolve_path(v_resolved, cwd, argv[arg_idx], PATH_MAX);
-                if (v_len == 0) { exit_code = 3; continue; }
+                if (v_len == 0) continue;
 
-                data.vp = (unsigned long long)(unsigned long)v_resolved;
-                ioctl_arg = &data;
+                nlh = init_msg(nm_family, is_add ? NOMOUNT_CMD_ADD_RULE : NOMOUNT_CMD_DEL_RULE, req_flags);
+                add_attr(nlh, NOMOUNT_ATTR_VIRTUAL_PATH, v_resolved, v_len + 1);
 
-                if (!is_add) {
-                    ioctl_code = IOCTL_DEL;
-                    long res = sys3(SYS_IOCTL, fd, ioctl_code, (long)ioctl_arg);
-                    if (res < 0) exit_code = -res;
-                } else { 
+                if (is_add) {
                     int r_len = resolve_path(r_resolved, cwd, argv[arg_idx+1], PATH_MAX);
-                    if (r_len == 0) { exit_code = 3; continue; }
-
-                    data.rp = (unsigned long long)(unsigned long)r_resolved;
-                    data.flags = 0;
-
-                    ioctl_code = IOCTL_ADD;
-                    long res = sys3(SYS_IOCTL, fd, ioctl_code, (long)ioctl_arg);
-                    if (res < 0) exit_code = -res;
+                    if (r_len == 0) continue;
+                    add_attr(nlh, NOMOUNT_ATTR_REAL_PATH, r_resolved, r_len + 1);
+                    unsigned int flags = 0;
+                    add_attr(nlh, NOMOUNT_ATTR_FLAGS, &flags, sizeof(flags));
                 }
+
+                long res = send_and_recv(fd, nlh);
+                if (res < 0) exit_code = -res;
             }
-            ioctl_code = 0; 
-            break;
+            goto do_exit;
         }
         case 'b':
         case 'u': {
             if (argc < 3) goto do_exit;
+            unsigned int uid = 0;
             const char *s = argv[2];
             while (*s) uid = uid * 10 + (*s++ - '0');
-            ioctl_arg = &uid;
-            ioctl_code = (cmd == 'b') ? IOCTL_ADD_UID : IOCTL_DEL_UID;
+
+            nlh = init_msg(nm_family, (cmd == 'b') ? NOMOUNT_CMD_ADD_UID : NOMOUNT_CMD_DEL_UID, req_flags);
+            add_attr(nlh, NOMOUNT_ATTR_UID, &uid, sizeof(uid));
             break;
         }
         case 'c':
-            ioctl_code = IOCTL_CLEAR;
+            nlh = init_msg(nm_family, NOMOUNT_CMD_CLEAR_ALL, req_flags);
             break;
         case 'v':
-            ioctl_code = IOCTL_VER;
+            nlh = init_msg(nm_family, NOMOUNT_CMD_GET_VERSION, req_flags);
             break;
-        case 'l':
-            ioctl_code = IOCTL_LIST;
-            ioctl_arg = list_buf;
-            break;
-        default:
+        case 'l': {
+            /* The Dumpit Magic for 'ls' */
+            nlh = init_msg(nm_family, NOMOUNT_CMD_GET_LIST, NLM_F_REQUEST | NLM_F_DUMP);
+            
+            struct sockaddr_nl dest = { .nl_family = AF_NETLINK };
+            sys6(SYS_SENDTO, fd, (long)nlh, nlh->nlmsg_len, 0, (long)&dest, sizeof(dest));
+
+            int is_json = (argc > 2 && argv[2][0] == 'j');
+            if (is_json) printc("[\n");
+            int first_item = 1;
+
+            while (1) {
+                long len = sys6(SYS_RECVFROM, fd, (long)rx_buf, sizeof(rx_buf), 0, 0, 0);
+                if (len <= 0) break;
+
+                int stop = 0;
+
+               for (struct nlmsghdr *msg = (struct nlmsghdr *)rx_buf; NLMSG_OK(msg, len); msg = NLMSG_NEXT(msg, len)) {
+                    if (msg->nlmsg_type == NLMSG_DONE || msg->nlmsg_type == NLMSG_ERROR) {
+                        stop = 1;
+                        break;
+                    }
+
+                    struct nlattr *tb[NOMOUNT_ATTR_PAYLOAD + 1];
+                    struct nlattr *attrs = (struct nlattr *)((char *)msg + NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct genlmsghdr)));
+                    int attr_len = msg->nlmsg_len - NLMSG_HDRLEN - NLMSG_ALIGN(sizeof(struct genlmsghdr));
+                    
+                    parse_attrs(tb, NOMOUNT_ATTR_PAYLOAD, attrs, attr_len);
+                    
+                    if (tb[NOMOUNT_ATTR_VIRTUAL_PATH] && tb[NOMOUNT_ATTR_REAL_PATH]) {
+                        char *v = (char *)tb[NOMOUNT_ATTR_VIRTUAL_PATH] + NLA_HDRLEN;
+                        char *r = (char *)tb[NOMOUNT_ATTR_REAL_PATH] + NLA_HDRLEN;
+                        
+                        if (is_json) {
+                            if (!first_item) printc(",\n");
+                            first_item = 0;
+                            printc("  {\n    \"virtual\": \"");
+                            sys3(SYS_WRITE, 1, (long)v, strlen(v));
+                            printc("\",\n    \"real\": \"");
+                            sys3(SYS_WRITE, 1, (long)r, strlen(r));
+                            printc("\"\n  }");
+                        } else {
+                            sys3(SYS_WRITE, 1, (long)v, strlen(v));
+                            printc(" -> ");
+                            sys3(SYS_WRITE, 1, (long)r, strlen(r));
+                            printc("\n");
+                        }
+                    }
+                    msg = (struct nlmsghdr *)((char *)msg + NLMSG_ALIGN(msg->nlmsg_len));
+                }
+                if (stop) break;
+            }
+            if (is_json) printc("\n]\n");
+            
+            exit_code = 0;
             goto do_exit;
+        }
     }
 
-    if (ioctl_code) {
-        long res = sys3(SYS_IOCTL, fd, ioctl_code, (long)ioctl_arg);
-        
+    if (nlh) {
+        long res = send_and_recv(fd, nlh);
+        exit_code = (res < 0) ? -res : 0;
+
         if (cmd == 'v' && res > 0) {
-            char v_buf[2] = {res + '0', '\n'};
-            sys3(SYS_WRITE, 1, (long)v_buf, 2);
-        }
-        else if (cmd == 'l' && res > 0) {
-            char *curr = (char *)ioctl_arg;
-            char *end = curr + res;
-            if (argc > 2 && argv[2][0] == 'j') {
-                char *json_out_buf = end;
-                int json_out_pos = 0;
-
-                #define append_const(str) do { \
-                    int _l = sizeof(str) - 1; \
-                    for (int _i = 0; _i < _l; _i++) json_out_buf[json_out_pos++] = (str)[_i]; \
-                } while(0)
-
-                #define append_str(s, l) do { \
-                    for (int _i = 0; _i < (l); _i++) json_out_buf[json_out_pos++] = (s)[_i]; \
-                } while(0)
-
-                append_const("[\n");
-
-                int is_first = 1;
-                while (curr < end) {
-                    unsigned short total_len = *(unsigned short *)curr;
-                    unsigned short v_len = *(unsigned short *)(curr + 2);
-                    
-                    if (total_len == 0) break;
-
-                    char *v_path = curr + 4;
-                    char *r_path = curr + 4 + v_len;
-                    int r_len = total_len - 4 - v_len;
-
-                    if (!is_first) append_const(",\n");
-                    is_first = 0;
-
-                    append_const("  {\n    \"virtual\": \"");
-                    append_str(v_path, v_len - 1);
-                    
-                    append_const("\",\n    \"real\": \"");
-                    if (r_len > 1) {
-                        append_str(r_path, r_len - 1);
-                    }
-                    append_const("\"\n  }");
-
-                    curr += total_len;
-                }
-                append_const("\n]\n");
-
-                sys3(SYS_WRITE, 1, (long)json_out_buf, json_out_pos);
-
-                #undef append_const
-                #undef append_str
-            } else {
-                while (curr < end) {
-                    unsigned short total_len = *(unsigned short *)curr;
-                    unsigned short v_len = *(unsigned short *)(curr + 2);
-                    
-                    if (total_len == 0) break;
-
-                    char *v_path = curr + 4;
-                    char *r_path = curr + 4 + v_len;
-                    int r_len = total_len - 4 - v_len;
-
-                    sys3(SYS_WRITE, 1, (long)v_path, v_len - 1);
-                    if (r_len > 1) {
-                        sys3(SYS_WRITE, 1, (long)" -> ", 4);
-                        sys3(SYS_WRITE, 1, (long)r_path, r_len - 1);
-                    }
-                    sys3(SYS_WRITE, 1, (long)"\n", 1);
-
-                    curr += total_len;
-                }
+            /* Handle Version Reply */
+            struct nlmsghdr *rep = (struct nlmsghdr *)rx_buf;
+            struct nlattr *tb[6];
+            struct nlattr *attrs = (struct nlattr *)((char *)rep + NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct genlmsghdr)));
+            int attr_len = rep->nlmsg_len - NLMSG_HDRLEN - NLMSG_ALIGN(sizeof(struct genlmsghdr));
+            
+            parse_attrs(tb, 5, attrs, attr_len);
+            if (tb[NOMOUNT_ATTR_VERSION]) {
+                unsigned int ver = *(unsigned int *)((char *)tb[NOMOUNT_ATTR_VERSION] + NLA_HDRLEN);
+                char v_str[2] = { ver + '0', '\n' };
+                sys3(SYS_WRITE, 1, (long)v_str, 2);
             }
         }
-        
-        exit_code = (res < 0) ? -res : 0;
     }
 
 do_exit:
+    if (fd >= 0) sys1(SYS_CLOSE, fd);
     sys1(SYS_EXIT, exit_code);
     __builtin_unreachable();
 }


### PR DESCRIPTION
This commit replaces the legacy character device (/dev/nomount) and IOCTL interface with a modern Generic Netlink (genl) architecture, establishing a safer and more scalable communication channel between userspace and kernel.

Kernel Space (nomount.c / nomount.h):
- Removed miscdevice registration and file operations.
- Implemented the 'nomount' Generic Netlink family.
- Replaced manual copy_from_user() and strndup_user() memory handling with Netlink's native attribute validation (NLA_NUL_STRING, NLA_U32), preventing potential buffer overflows from malformed userspace inputs.
- Converted the monolithic rule listing IOCTL into a stateful Netlink multipart message stream using the .dumpit callback, bypassing socket buffer size limits for systems with a large number of active rules.
- Consolidated and cleaned up redundant IOCTL data structures.

Userspace CLI (nm.c):
- Rewrote the freestanding CLI to construct and parse Netlink packets via raw AF_NETLINK sockets (sys_socket, sys_bind, sys_sendto, sys_recvfrom).
- Implemented custom standard memory operations (memset, memcpy, strlen) as global symbols. This satisfies LLVM linker dependencies generated by aggressive size optimization (-Oz) without requiring external libc.
- Adopted canonical NLMSG_OK and NLMSG_NEXT macros to securely iterate through Netlink multipart responses, preventing out-of-bounds memory access during payload extraction.
- Set TX/RX static buffers to 16KB to accommodate maximum length path attributes (PATH_MAX).

Module Scripts (customize.sh / metamount.sh):
- Deprecated static /dev/nomount file checks. Module availability is now validated dynamically via an End-to-End Netlink query ('nm v').