### PR TITLE
fs: nomount: add missing #include <linux/module.h>

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -4,6 +4,7 @@
 #include <linux/cred.h>
 #include <linux/xattr.h>
 #include <linux/version.h>
+#include <linux/module.h>
 #include "nomount.h"
 
 static struct kmem_cache *nm_dir_cachep __read_mostly, *nm_uid_cachep __read_mostly;


### PR DESCRIPTION
Include <linux/module.h> to resolve compilation errors caused by undefined MODULE_LICENSE, MODULE_VERSION, module_init, and module_exit macros.

Without this header, the compiler treats these macros as function parameter declarations, resulting in errors such as:
- error: expected parameter declarator
- error: type specifier missing, defaults to 'int'
- error: a function declaration without a prototype is deprecated

This fix allows the module to build successfully.