### PR TITLE
Fix implicit declaration function of fput

### DIFF
--- a/kernel/src/nomount.h
+++ b/kernel/src/nomount.h
@@ -6,6 +6,7 @@
 #include <linux/list.h>
 #include <linux/hashtable.h>
 #include <linux/atomic.h>
+#include <linux/file.h>
 #include <net/sock.h>
 #include <net/genetlink.h>
 #include <linux/version.h>


### PR DESCRIPTION
Tested: K4.14 MTK
Following error:
../fs/nomount.c:152:9: error: implicit declaration of function 'fput' [-Werror,-Wimplicit-function-declaration]