### PR TITLE
Fix declaration-after-statement in nomount_hijacked_iterate_dir()

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -639,6 +639,9 @@ fallback:
 static int nomount_hijacked_iterate_dir(struct file *file, struct dir_context *ctx)
 {
     struct nm_fop *nm_fop = __get_nm(smp_load_acquire(&file->f_op), struct nm_fop, fake_fop);
+    struct nomount_proxy_ctx proxy_ctx = {
+        .ctx.actor = nomount_actor_proxy,
+    };
     int res = 0;
 
     if (unlikely(nomount_is_uid_blocked(current_uid().val) || !nm_fop || !nm_fop->orig_fop || !nm_fop->dir_node))
@@ -649,10 +652,10 @@ static int nomount_hijacked_iterate_dir(struct file *file, struct dir_context *c
         return 0;
     }
 
-    struct nomount_proxy_ctx proxy_ctx = {
-        .ctx.actor = nomount_actor_proxy, .ctx.pos = ctx->pos,
-        .orig_ctx = ctx, .dir_node = nm_fop->dir_node, .emitted = 0
-    };
+    proxy_ctx.ctx.pos = ctx->pos;
+    proxy_ctx.orig_ctx = ctx;
+    proxy_ctx.dir_node = nm_fop->dir_node;
+    proxy_ctx.emitted = 0;
 
     res = nm_call_iterate(file, &proxy_ctx.ctx, nm_fop->orig_fop);
     ctx->pos = proxy_ctx.ctx.pos;


### PR DESCRIPTION
Following warning:
../fs/nomount.c:652:30: warning: mixing declarations and code is a C99 extension [-Wdeclaration-after-statement]
  652 |     struct nomount_proxy_ctx proxy_ctx = {
      |                              ^
1 warning generated.

try move proxy_ctx declaration to the top of nomount_hijacked_iterate_dir() and initialize remaining fields explicitly to comply with kernel declaration rules without violating const-qualified struct members.