### PR TITLE
kernel: DCACHE_DONTCACHE the blocked reader's shadow dentry

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -263,7 +263,18 @@ static struct dentry *nomount_hijacked_lookup(struct inode *dir, struct dentry *
 fallback:
     if (nm_iop && nm_iop->dir_node && nomount_is_uid_blocked(current_uid().val)) {
         if (nomount_get_rule_info(nm_iop->dir_node, name, len, full_name_hash(NULL, name, len), &rule_info)) {
+            /* This reader is blocked but the name IS injected: the stock/negative
+             * dentry the real lookup below is about to cache would sit in the
+             * SHARED dcache and hide the injection from every other UID (root
+             * included) until drop_caches/reboot -- d_invalidate() is a no-op on a
+             * negative, so nm_d_revalidate cannot evict it. DCACHE_DONTCACHE drops
+             * it on the last dput instead, so the blocked reader still gets its
+             * stock view for this call and the next lookup by anyone re-resolves
+             * cleanly. (>=5.13; older trees fall back to the d_revalidate path.) */
             nm_install_dentry_ops(dentry);
+#ifdef DCACHE_DONTCACHE
+            dentry->d_flags |= DCACHE_DONTCACHE;
+#endif
             if (rule_info.r_path.dentry) path_put(&rule_info.r_path);
         }
     }

--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -263,14 +263,6 @@ static struct dentry *nomount_hijacked_lookup(struct inode *dir, struct dentry *
 fallback:
     if (nm_iop && nm_iop->dir_node && nomount_is_uid_blocked(current_uid().val)) {
         if (nomount_get_rule_info(nm_iop->dir_node, name, len, full_name_hash(NULL, name, len), &rule_info)) {
-            /* This reader is blocked but the name IS injected: the stock/negative
-             * dentry the real lookup below is about to cache would sit in the
-             * SHARED dcache and hide the injection from every other UID (root
-             * included) until drop_caches/reboot -- d_invalidate() is a no-op on a
-             * negative, so nm_d_revalidate cannot evict it. DCACHE_DONTCACHE drops
-             * it on the last dput instead, so the blocked reader still gets its
-             * stock view for this call and the next lookup by anyone re-resolves
-             * cleanly. (>=5.13; older trees fall back to the d_revalidate path.) */
             nm_install_dentry_ops(dentry);
 #ifdef DCACHE_DONTCACHE
             dentry->d_flags |= DCACHE_DONTCACHE;


### PR DESCRIPTION
### Problem

When a UID is blocked (per-UID hiding), its `nomount_hijacked_lookup` falls through to the real fs, which caches a **stock/negative** dentry for a path that *is* injected. That dentry lives in the **shared** dcache, so it hides the injection from **every other UID — root included** — until `drop_caches`/reboot.

`nm_d_revalidate` cannot fix this after the fact: `d_invalidate()` is a **no-op on a negative dentry**, so returning 0 (invalid) from revalidate leaves the poisoned negative hashed and the next lookup just finds it again.

### Fix

At the blocked-reader fallback (where we already `nm_install_dentry_ops()`), also mark the dentry `DCACHE_DONTCACHE`. The kernel then drops it on the last `dput()`, so:
- the blocked reader still gets its stock view for *this* call, and
- the next lookup by anyone re-resolves per-UID cleanly.

`#ifdef`-guarded — `DCACHE_DONTCACHE` exists since 5.13; older trees keep relying on the existing `d_revalidate` re-resolve.

One site, ~3 lines.

### Validation

Carried downstream in `Bouteillepleine/kbuild@hookless`, **boot-verified on a OnePlus 15 (6.12)**. Before it, blocking a detector's UID intermittently hid the injected files from root too (until reboot); with it, `blocked → stock` and `root → injected` stay consistent across readers. Compile-clean across the 4.9→6.18 GKI matrix.
