### PR TITLE
Small shadow/clear correctness follow-ups

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -1173,10 +1173,6 @@ static void nomount_prune_empty_virtual_dirs(struct nomount_dir_node *dir_node, 
     while (dir_node && idr_is_empty(&dir_node->children_idr)) {
         owner = dir_node->_tag_ptr & 1UL ? (struct nomount_rule *)(dir_node->_tag_ptr & ~1UL) : NULL;
         if (!owner) break;
-
-        /* After shadow-reparenting, a real injection can end up owning a virtual
-         * subtree; it must survive when that subtree empties. Only pure virtual
-         * dirs are prunable. For a real owner just detach and free the empty node. */
         if (!(owner->flags & NM_FLAG_VIRTUAL_DIR)) {
             owner->this_dir = NULL;
             call_rcu(&dir_node->rcu, nm_dir_rcu_free);
@@ -1264,9 +1260,8 @@ static int __nomount_add_rule(const char *v_path, const char *r_path, u16 v_len,
 
     mutex_lock(&nomount_write_mutex);
     hash_for_each_possible(nomount_rules_ht, existing, vpath_node, rule->v_hash) {
-        if (existing->v_hash == rule->v_hash && existing->v_len == v_len &&
-             existing->target_uid == target_uid &&
-             memcmp(nm_get_vpath(existing), nm_get_vpath(rule), v_len) == 0) {
+        if (existing->v_hash == rule->v_hash && existing->v_len == v_len && existing->target_uid == target_uid &&
+                memcmp(nm_get_vpath(existing), nm_get_vpath(rule), v_len) == 0) {
             if (existing->this_dir) {
                 if (rule->this_dir) call_rcu(&rule->this_dir->rcu, nm_dir_rcu_free);
                 rule->this_dir = existing->this_dir;
@@ -1331,9 +1326,6 @@ static void __nomount_clear_all(int clear_flags)
 
     if (clear_flags & NM_CLEAR_UIDS) {
         static_branch_disable(&nomount_active_uids);
-        /* nomount_is_uid_blocked() does a lockless idr_find() under rcu_read_lock();
-         * let readers that already passed the static branch drain before idr_destroy()
-         * frees the radix nodes underneath them. */
         synchronize_rcu();
         idr_destroy(&nomount_uid_idr);
         if (!(clear_flags & NM_CLEAR_EXIT)) idr_init(&nomount_uid_idr);

--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -1174,6 +1174,15 @@ static void nomount_prune_empty_virtual_dirs(struct nomount_dir_node *dir_node, 
         owner = dir_node->_tag_ptr & 1UL ? (struct nomount_rule *)(dir_node->_tag_ptr & ~1UL) : NULL;
         if (!owner) break;
 
+        /* After shadow-reparenting, a real injection can end up owning a virtual
+         * subtree; it must survive when that subtree empties. Only pure virtual
+         * dirs are prunable. For a real owner just detach and free the empty node. */
+        if (!(owner->flags & NM_FLAG_VIRTUAL_DIR)) {
+            owner->this_dir = NULL;
+            call_rcu(&dir_node->rcu, nm_dir_rcu_free);
+            break;
+        }
+
         hash_del_rcu(&owner->vpath_node);
         if (owner->parent_dir) __nomount_delete_child_locked(owner);
         nm_debug("Pruned empty virtual directory: %s\n", nm_get_vpath(owner));
@@ -1256,6 +1265,7 @@ static int __nomount_add_rule(const char *v_path, const char *r_path, u16 v_len,
     mutex_lock(&nomount_write_mutex);
     hash_for_each_possible(nomount_rules_ht, existing, vpath_node, rule->v_hash) {
         if (existing->v_hash == rule->v_hash && existing->v_len == v_len &&
+             existing->target_uid == target_uid &&
              memcmp(nm_get_vpath(existing), nm_get_vpath(rule), v_len) == 0) {
             if (existing->this_dir) {
                 if (rule->this_dir) call_rcu(&rule->this_dir->rcu, nm_dir_rcu_free);
@@ -1321,6 +1331,10 @@ static void __nomount_clear_all(int clear_flags)
 
     if (clear_flags & NM_CLEAR_UIDS) {
         static_branch_disable(&nomount_active_uids);
+        /* nomount_is_uid_blocked() does a lockless idr_find() under rcu_read_lock();
+         * let readers that already passed the static branch drain before idr_destroy()
+         * frees the radix nodes underneath them. */
+        synchronize_rcu();
         idr_destroy(&nomount_uid_idr);
         if (!(clear_flags & NM_CLEAR_EXIT)) idr_init(&nomount_uid_idr);
     }


### PR DESCRIPTION
Hey max, I've been poking at the same hookless engine and really like the reparenting approach you just landed for the shadow UAF. Going back through the shadow/clear paths I hit a few adjacent edge cases, so I bundled some small updates here. All three use existing helpers, take or reshape whatever's useful.

### 1. Drain RCU readers before idr_destroy on uid clear

`nomount_is_uid_blocked()` does a lockless `idr_find()` inside `rcu_read_lock()`. On `__nomount_clear_all(NM_CLEAR_UIDS)` the idr is destroyed right after `static_branch_disable()` with no grace period in that path, so a reader that already passed the static branch can still be walking radix nodes that `idr_destroy()` frees underneath it. Adding a `synchronize_rcu()` before the destroy lets those readers drain first. Trigger is `nm clear` racing a path lookup while uid-blocking is on.

### 2. Match target_uid when shadowing an existing rule

The shadow match in `__nomount_add_rule` keys on vpath only, while `__nomount_del_rule` matches including `target_uid`. So adding a per-uid rule at a vpath silently replaces a rule for a different uid at the same path, and with the new reparenting it also adopts that rule's subtree across uids. One-liner: also compare `existing->target_uid == target_uid`.

### 3. Keep a real injection that owns a reparented subtree from being pruned

Side effect of the reparent: a real (file) injection can end up owning a virtual subtree with `_tag_ptr` repointed at that rule. When the subtree later empties, `nomount_prune_empty_virtual_dirs()` reads the `_tag_ptr` owner and frees it, so the real injection disappears. Repro:

```
nm add /a/b/c/x /real1     # virtual parent /a/b/c owns child x
nm add /a/b/c   /real2      # /a/b/c (file) reparents x's dir_node
nm del /a/b/c/x             # subtree empties, /a/b/c gets pruned away
```

The guard only prunes pure `NM_FLAG_VIRTUAL_DIR` owners. For a real owner it detaches and frees just the empty node so the rule survives.

Thanks for the engine, the reparenting idea is clean.
