### PR TITLE
fix(userspace): reset payload->arg1 before batched send

### DIFF
--- a/userspace/src/nm.c
+++ b/userspace/src/nm.c
@@ -79,6 +79,7 @@ void c_main(long *sp) {
 
             exit_code = 0;
             payload->cmd = target_cmd;
+            payload->arg1 = 0;
             payload->data_size = 0;
             char *cursor = payload->buffer;
 
@@ -102,6 +103,7 @@ void c_main(long *sp) {
                     exit_code |= (nm_send_payload(payload) < 0);
                     cursor = payload->buffer;
                     payload->cmd = target_cmd;
+                    payload->arg1 = 0;
                 }
 
                 if (target_cmd == NM_CMD_ADD_RULE) {


### PR DESCRIPTION
## Problem
- When a rule add/del has enough entries to not fit in one payload buffer (3900B), `nm.c` (userspace) sends it in multiple batches, reusing the same payload struct each time

- Kernel uses `payload->arg1` as a cursor while parsing the buffer, writes final value back into the struct. But `nm.c` never reset it before sending next batch. This leads to the second (or later) batch starts with leftover arg1 that's already >= the new data_size. The kernel's while loop never runs, and that batch gets silently dropped (silently, no error)

## Result
- Large rule set (or module needs to mount many files) only get partially mounted

## Fix
- set `payload->arg1 = 0` before sending each batch.

Tested with a module big enough to need 2 batches. Before this fix, only first batch applied (half of module mounted), after this fix, all batches applied successfully (full module mounted)