### PR TITLE
kernel: stale `err` in the topology walk frees live rules

### DIFF
--- a/kernel/src/nomount.c
+++ b/kernel/src/nomount.c
@@ -1129,10 +1129,10 @@ static int nomount_generate_virtual_topology(struct nomount_rule *target_rule)
 
         char orig_vpath = v_path[i];
         if (i > 0) v_path[i] = '\0';
-        err = kern_path((parent_len == 1) ? "/" : v_path, LOOKUP_FOLLOW, &p_path);
+        int rc = kern_path((parent_len == 1) ? "/" : v_path, LOOKUP_FOLLOW, &p_path);
         if (i > 0) v_path[i] = orig_vpath;
 
-        if (err == 0) {
+        if (rc == 0) {
             struct inode *v_inode = d_backing_inode(p_path.dentry);
             dir_node = nomount_get_dir_node(v_inode);
             if (!dir_node) dir_node = __nomount_alloc_dir_node(v_inode);


### PR DESCRIPTION
`kern_path()` failing in `nomount_generate_virtual_topology()` is the normal case, it just means the parent becomes a virtual dir. It lands in `err` now, and the `ex` branch breaks without clearing it.

```
nm add /product/foo /data/x
nm add /product/foo/bar/baz /data/y
```

Second add: `/product/foo/bar` is not in the tree or on disk, so `err = -ENOENT`, the intermediate gets made and `baz` injected. Next round finds `/product/foo`, injects `bar`, breaks with `err` still set. Cleanup frees the intermediate while `/product/foo` still points at it, and `__nomount_add_rule()` frees the target rule too. Next `ls` there reads freed memory.

`kern_path` gets its own variable, `err` still catches the ENOMEMs.

6.12.23 arm64, clang 18, `W=1` clean.
