### PR TITLE
Fix Turkish translation for "exclusions"

### DIFF
--- a/module/webroot/locales/tr.json
+++ b/module/webroot/locales/tr.json
@@ -1,7 +1,7 @@
 {
   "nav_home": "Ana Sayfa",
   "nav_modules": "Modüller",
-  "nav_exclusions": "Yatırmalar",
+  "nav_exclusions": "Hariç Tutulanlar",
   "nav_options": "Seçenekler",
   "injection-stats": "Hesaplanıyor...",
   "status_checking": "Kontrol ediliyor...",


### PR DESCRIPTION
The term 'Yatırmalar', which was used for the 'nav_exclusions' key in the Turkish localization file  and was completely out of context, has been corrected to 'Hariç Tutulanlar' to properly fit the project's functionality.